### PR TITLE
Added user config file check per the XDG Base Spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ dcm.conf: This is the configuration file for dcm.pl. dcm.pl will look for
 
     `'./.dcm/dcm.conf'`,
     `'./dcm.conf'`,
+    `$xdg_config_home . '/dcm/dcm.conf'`,
+    `$homedir . '/.config/dcm/dcm.conf'`,
     `$homedir . '/.dcm/dcm.conf'`,
     `$homedir . '/dcm.conf'`,
     `$onabase . '/etc/dcm.conf'`,

--- a/dcm.pl
+++ b/dcm.pl
@@ -1328,11 +1328,13 @@ $onabase =~ s/\s+$//;
 ## Search for a configuration file
 my $homedir = "~";
 if ($ENV{'HOME'}) { $homedir = $ENV{'HOME'}; }
+my $xdg_config_home = $ENV{'XDG_CONFIG_HOME'} || $homedir . '/.config';
 if ($ENV{'HOMEDRIVE'} and $ENV{'HOMEPATH'}) { $homedir = $ENV{'HOMEDRIVE'} . $ENV{'HOMEPATH'}; }
 my @file_list = (
     $conf{'configurationFile'},
     './.dcm/dcm.conf',
     './dcm.conf',
+    $xdg_config_home . '/dcm/dcm.conf',
     $homedir . '/.dcm/dcm.conf',
     $homedir . '/dcm.conf',
     $onabase . '/etc/dcm.conf',


### PR DESCRIPTION
This commit adds the [XDG Base Directory Spec](http://standards.freedesktop.org/basedir-spec/latest/) user-local config path to the list of locations searched for `dcm.conf`.

This spec allows users to consolidate their dotfiles to reduce the clutter in their `$HOME`.
### Per the spec:
1. Check if a path is specified in the environmental variable: `$XDG_CONFIG_HOME`
2. If undefined, use the default base path: `~/.config`
3. By convention, the config file is in a sub-directory named for the app: `dcm/dcm.conf`

Put it all together and the config path will normally be: `~/.config/dcm/dcm.conf`

If the path doesn't exist, the other dotfile paths are checked as usual, so existing users aren't left behind.

I've updated `README.md` accordingly.
