### PR TITLE
Two minor bug fixes....

### DIFF
--- a/bin/dcm.pl
+++ b/bin/dcm.pl
@@ -71,6 +71,9 @@
 ##  
 ##  Changelog:
 ##
+##      12/30/2015 - v1.24 - David Holland
+##          - Make certain options files are actually files. 
+##          - Fix chunked encoding to transfer more than one chunk.
 ##	10/22/2015 - v1.23 - Matt Pascoe
 ##          - move to bin and etc dirs as well as create a make-package script
 ##	10/19/2015 - v1.22 - Matt Pascoe
@@ -193,9 +196,9 @@ my %conf = (
     'colorCyan'            => "\033[36;1m",
     
     ## Script specific settings
-    'version'              => '1.23',                          ## The version of this program
-    'authorName'           => 'Brandon Zehm/Matt Pascoe',      ## Author's Name
-    'authorEmail'          => 'caspian@dotconf.net/matt@opennetadmin.com',           ## Author's Email Address
+    'version'              => '1.24',                          ## The version of this program
+    'authorName'           => 'Brandon Zehm/Matt Pascoe/David Holland',      ## Author's Name
+    'authorEmail'          => 'caspian@dotconf.net/matt@opennetadmin.com/david.w.holland@gmail.com',           ## Author's Email Address
     'configurationFile'    => '',                              ## Configuration file location
     
 );

--- a/bin/dcm.pl
+++ b/bin/dcm.pl
@@ -1412,7 +1412,7 @@ my $option_string = "";
 $opt{'unix_username'} = $conf{'unix_username'};
 foreach my $key (keys(%opt)) {
     ## If the value specified is a file, or -, load the file's contents (or STDIN) as the value
-    if ( (-e $opt{$key} and -r $opt{$key}) or ($opt{$key} eq '-') ) {
+    if ( (-e $opt{$key} and -r $opt{$key} and -f $opt{$key} ) or ($opt{$key} eq '-') ) {
         my $FILE;
         if(!open($FILE, ' ' . $opt{$key})) {
             quit("ERROR => couldn't open input file, $opt{$key}, $!", 1);


### PR DESCRIPTION
The first should be "obvious". 

The second fixes HTTP chunked encoded transfers, so they'll transfer more than one chunk.  (and eliminates the extra cLength variable.) 

I'm still not certain its 100% RFC compliant, but I ran into the chunked problem, with truncated zone files, in the home environment, and the below code changes fix it. 
