### PR TITLE
Added instructions for dcm.pl user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ url but just tack on dcm.php. Some examples might be:
     url                      => https://localhost/ona/dcm.php
     url                      => http://myserver.example.com/ipam/dcm.php
 
+The dcm.pl user will also need to be manually created.  For more detail on
+how you can leverage a different user, please see the SECURITY section.
+Once that user is created, be sure to also give it the "interface_modify"
+and "ona_sql" permissions via the Permissions Editor in the ONA GUI.
 
 SECURITY
 --------

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ url but just tack on dcm.php. Some examples might be:
     url                      => https://localhost/ona/dcm.php
     url                      => http://myserver.example.com/ipam/dcm.php
 
-The dcm.pl user will also need to be manually created.  For more detail on
-how you can leverage a different user, please see the SECURITY section.
-Once that user is created, be sure to also give it the "interface_modify"
-and "ona_sql" permissions via the Permissions Editor in the ONA GUI.
+The dcm.pl user will also need to be manually created via the ONA GUI.  For
+ more detail on how you can leverage a different user, please see the 
+SECURITY section. Once that user is created, be sure to also give it the 
+"interface_modify" and "ona_sql" permissions via the Permissions Editor - 
+also in the ONA GUI.
 
 SECURITY
 --------


### PR DESCRIPTION
I ran into the problem referenced in this post after a fresh install of ONA:
http://opennetadmin.com/forum_archive/4/t-180.html

Since this document is referenced via the link within the nmap plugin in ONA, I wanted to update the instructions to include its creation - hopefully this will help others that ran into the same problem I did.